### PR TITLE
feat: fix type issues

### DIFF
--- a/.changes/unreleased/Fixed-20250506-095400.yaml
+++ b/.changes/unreleased/Fixed-20250506-095400.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed missing `__init__` return type annotation and connection parameter type when using `asyncpg` driver.
+time: 2025-05-06T09:54:00.0000000+01:00
+custom:
+  Author: tandemdude
+  PR: "50"

--- a/internal/codegen/drivers/asyncpg.go
+++ b/internal/codegen/drivers/asyncpg.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const AsyncpgConn = "asyncpg.Connection"
+const AsyncpgConn = "asyncpg.Connection[asyncpg.Record]"
 
 func AsyncpgBuildPyQueryFunc(query *core.Query, body *builders.IndentStringBuilder, args []string, retType string, isClass bool) error {
 	indentLevel := 0

--- a/internal/codegen/queries.go
+++ b/internal/codegen/queries.go
@@ -80,7 +80,7 @@ func (dr *Driver) buildClassTemplate(sourceName string, body *builders.IndentStr
 	body.WriteLine(fmt.Sprintf("class %s:", className))
 	body.WriteIndentedLine(1, `__slots__ = ("_conn",)`)
 	body.NewLine()
-	body.WriteIndentedLine(1, fmt.Sprintf(`def __init__(self, conn: %s):`, dr.connType))
+	body.WriteIndentedLine(1, fmt.Sprintf(`def __init__(self, conn: %s) -> None:`, dr.connType))
 	body.WriteIndentedLine(2, "self._conn = conn")
 	body.NewLine()
 	return className


### PR DESCRIPTION
Fixes the `Queries` class init method missing a return type annotation, and the `conn` parameter type hint missing a generic parameter for the `asyncpg` driver.