### PR TITLE
Add Github Profile link in the changelog

### DIFF
--- a/.changes/unreleased/Added-20250509-081237.yaml
+++ b/.changes/unreleased/Added-20250509-081237.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added hyperlink to github profile of contributors in the changelog
+time: 2025-05-09T08:12:37.82307Z
+custom:
+    Author: rayakame
+    PR: "59"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -5,7 +5,7 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '* [#{{.Custom.PR}}](https://github.com/rayakame/sqlc-gen-better-python/pull/{{.Custom.PR}}) {{.Body}} ({{.Custom.Author}})'
+changeFormat: '* [#{{.Custom.PR}}](https://github.com/rayakame/sqlc-gen-better-python/pull/{{.Custom.PR}}) {{.Body}} ([{{.Custom.Author}}]({{.Custom.Author}}))'
 custom:
   - key: PR
     type: int


### PR DESCRIPTION
Updated changeFormat in .changie.yaml to include a link to the author's profile. (feature/link-author-im-changelog)