### PR TITLE
ci: read the Go version for test-build from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.24.1'
+          go-version-file: './go.mod'
 
       - name: Make build script executable
         run: chmod +x scripts/build/build.sh


### PR DESCRIPTION
The hardcoded Go 1.24.1 in test-build fails any dependency bump that raises the go.mod directive (x/net 0.55 and x/text 0.40 need go 1.25); GOTOOLCHAIN=local prevents the auto-download. release.yml already uses go-version-file, so test-build now matches and both always build with the same toolchain. Unblocks dependabot PRs 166, 168 and 152.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build checks to use the Go version specified by the project, improving consistency across development and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->