### PR TITLE
test: restore 100% python coverage, add combined go+py codecov flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           go-version-file: './go.mod'
 
       - name: Run go tests
-        run: go test -shuffle=on -coverprofile=coverage.out -coverpkg=./internal/... ./...
+        run: go test -shuffle=on -coverprofile=coverage.out -coverpkg=./internal/...,./plugin/... ./...
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
   upload-coverage:
     needs: [ test ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python
 
 
 
@@ -230,7 +231,14 @@ jobs:
           go-version-file: './go.mod'
 
       - name: Run go tests
-        run: go test -shuffle=on ./...
+        run: go test -shuffle=on -coverprofile=coverage.out -coverpkg=./internal/... ./...
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          flags: go
 
   go-lint:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,12 @@ linters:
     - wastedassign
     - whitespace
     - exhaustruct
+  exclusions:
+    rules:
+      # Partially initialized fixture structs are the point of table tests.
+      - path: _test\.go
+        linters:
+          - exhaustruct
   settings:
     mnd:
       # The int argument of these is an indent level / newline count.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,10 +87,12 @@ linters:
     - exhaustruct
   exclusions:
     rules:
-      # Partially initialized fixture structs are the point of table tests.
+      # Partially initialized fixture structs and repeated fixture literals
+      # are the point of table tests.
       - path: _test\.go
         linters:
           - exhaustruct
+          - goconst
   settings:
     mnd:
       # The int argument of these is an indent level / newline count.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sqlc-gen-better-python
 
 [![Codecov](https://codecov.io/gh/rayakame/sqlc-gen-better-python/graph/badge.svg?token=LROCMXW6MC)](https://codecov.io/gh/rayakame/sqlc-gen-better-python)
+[![Go coverage](https://img.shields.io/codecov/c/github/rayakame/sqlc-gen-better-python?flag=go&label=go%20coverage)](https://app.codecov.io/gh/rayakame/sqlc-gen-better-python/flags)
+[![Python coverage](https://img.shields.io/codecov/c/github/rayakame/sqlc-gen-better-python?flag=python&label=python%20coverage)](https://app.codecov.io/gh/rayakame/sqlc-gen-better-python/flags)
 ![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Frayakame%2Fsqlc-gen-better-python%2Fmain%2Fpyproject.toml)
 ![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)
 [![CI](https://github.com/rayakame/sqlc-gen-better-python/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rayakame/sqlc-gen-better-python/actions/workflows/ci.yml)

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,22 @@ codecov:
   bot: "Code Coverage"
   strict_yaml_branch: "main"
   max_report_age: 24
+
+# Go and Python coverage are uploaded as separate flags (go-test job and
+# upload-coverage job in ci.yml); the project number combines both.
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+      - type: patch
+        target: auto
+  individual_flags:
+    - name: go
+      paths:
+        - internal/
+        - plugin/
+    - name: python
+      paths:
+        - test/

--- a/internal/transform/enums.go
+++ b/internal/transform/enums.go
@@ -5,14 +5,14 @@ import (
 	"slices"
 
 	"github.com/rayakame/sqlc-gen-better-python/internal/model"
-	"github.com/rayakame/sqlc-gen-better-python/internal/utils"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
 )
 
 func (t *Transformer) BuildEnums() []model.Enum {
 	enums := make([]model.Enum, 0)
 	seenNames := make(map[string]int)
 	for _, schema := range t.req.Catalog.Schemas {
-		if schema.Name == utils.PgCatalog || schema.Name == utils.InformationSchema {
+		if schema.Name == types.PgCatalog || schema.Name == types.InformationSchema {
 			continue
 		}
 		for _, enum := range schema.Enums {

--- a/internal/transform/enums_test.go
+++ b/internal/transform/enums_test.go
@@ -1,0 +1,37 @@
+package transform_test
+
+import (
+	"testing"
+
+	"github.com/rayakame/sqlc-gen-better-python/internal/config"
+	"github.com/rayakame/sqlc-gen-better-python/internal/transform"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
+	"github.com/sqlc-dev/plugin-sdk-go/plugin"
+)
+
+func TestBuildEnumsSkipsSystemSchemas(t *testing.T) {
+	t.Parallel()
+	req := &plugin.GenerateRequest{
+		Catalog: &plugin.Catalog{
+			DefaultSchema: "public",
+			Schemas: []*plugin.Schema{
+				{Name: types.PgCatalog, Enums: []*plugin.Enum{{Name: "hidden_pg", Vals: []string{"a"}}}},
+				{Name: types.InformationSchema, Enums: []*plugin.Enum{{Name: "hidden_info", Vals: []string{"b"}}}},
+				{Name: "public", Enums: []*plugin.Enum{{Name: "test_mood", Vals: []string{"happy", "sad"}}}},
+			},
+		},
+	}
+	tf := transform.NewTransformer(&config.Config{}, req, types.PostgresTypeToPython)
+
+	enums := tf.BuildEnums()
+
+	if len(enums) != 1 {
+		t.Fatalf("BuildEnums returned %d enums, want 1 (system schemas must be skipped)", len(enums))
+	}
+	if enums[0].Name != "TestMood" {
+		t.Errorf("enum name = %q, want %q", enums[0].Name, "TestMood")
+	}
+	if len(enums[0].Constants) != 2 {
+		t.Errorf("enum has %d constants, want 2", len(enums[0].Constants))
+	}
+}

--- a/internal/transform/tables.go
+++ b/internal/transform/tables.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/rayakame/sqlc-gen-better-python/internal/model"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
 	"github.com/rayakame/sqlc-gen-better-python/internal/utils"
 	"github.com/sqlc-dev/plugin-sdk-go/plugin"
 )
@@ -15,7 +16,7 @@ func (t *Transformer) BuildTables() []model.Table {
 	// digit-leading names sharing the Model prefix).
 	seen := make(map[string]int)
 	for _, schema := range t.req.Catalog.Schemas {
-		if schema.Name == utils.PgCatalog || schema.Name == utils.InformationSchema {
+		if schema.Name == types.PgCatalog || schema.Name == types.InformationSchema {
 			continue
 		}
 		for _, table := range schema.Tables {

--- a/internal/transform/tables_test.go
+++ b/internal/transform/tables_test.go
@@ -1,0 +1,47 @@
+package transform_test
+
+import (
+	"testing"
+
+	"github.com/rayakame/sqlc-gen-better-python/internal/config"
+	"github.com/rayakame/sqlc-gen-better-python/internal/transform"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
+	"github.com/sqlc-dev/plugin-sdk-go/plugin"
+)
+
+func TestBuildTablesSkipsSystemSchemas(t *testing.T) {
+	t.Parallel()
+	req := &plugin.GenerateRequest{
+		Catalog: &plugin.Catalog{
+			DefaultSchema: "public",
+			Schemas: []*plugin.Schema{
+				{
+					Name:   types.PgCatalog,
+					Tables: []*plugin.Table{{Rel: &plugin.Identifier{Name: "pg_class"}}},
+				},
+				{
+					Name: "public",
+					Tables: []*plugin.Table{{
+						Rel: &plugin.Identifier{Name: "test_items"},
+						Columns: []*plugin.Column{
+							{Name: "id", Type: &plugin.Identifier{Name: "int4"}, NotNull: true},
+						},
+					}},
+				},
+			},
+		},
+	}
+	tf := transform.NewTransformer(&config.Config{}, req, types.PostgresTypeToPython)
+
+	tables := tf.BuildTables()
+
+	if len(tables) != 1 {
+		t.Fatalf("BuildTables returned %d tables, want 1 (system schemas must be skipped)", len(tables))
+	}
+	if tables[0].Name != "TestItem" {
+		t.Errorf("table name = %q, want %q (singularized CapWords)", tables[0].Name, "TestItem")
+	}
+	if len(tables[0].Columns) != 1 || tables[0].Columns[0].DBName != "id" {
+		t.Errorf("columns = %+v, want a single id column", tables[0].Columns)
+	}
+}

--- a/internal/transform/type.go
+++ b/internal/transform/type.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/rayakame/sqlc-gen-better-python/internal/config"
 	"github.com/rayakame/sqlc-gen-better-python/internal/model"
-	"github.com/rayakame/sqlc-gen-better-python/internal/utils"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
 	"github.com/sqlc-dev/plugin-sdk-go/plugin"
 	"github.com/sqlc-dev/plugin-sdk-go/sdk"
 )
@@ -32,7 +32,7 @@ func (t *Transformer) buildPyType(pluginColumn *plugin.Column) model.PyType {
 	}
 
 	for _, schema := range t.req.Catalog.Schemas {
-		if schema.Name == utils.PgCatalog || schema.Name == utils.InformationSchema {
+		if schema.Name == types.PgCatalog || schema.Name == types.InformationSchema {
 			continue
 		}
 		if typeSchema != schema.GetName() {

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -1,5 +1,7 @@
 package types
 
+// Python type names emitted into generated code. Bool and Boolean double as
+// SQL type spellings in the conversion tables.
 const (
 	Bool    = "bool"
 	Boolean = "boolean"
@@ -8,4 +10,10 @@ const (
 	Float   = "float"
 	Decimal = "decimal.Decimal"
 	Any     = "typing.Any"
+)
+
+// SQL system schemas whose objects are never rendered as models or enums.
+const (
+	InformationSchema = "information_schema"
+	PgCatalog         = "pg_catalog"
 )

--- a/internal/types/postgresql.go
+++ b/internal/types/postgresql.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rayakame/sqlc-gen-better-python/internal/config"
 	"github.com/rayakame/sqlc-gen-better-python/internal/log"
 	"github.com/rayakame/sqlc-gen-better-python/internal/model"
-	"github.com/rayakame/sqlc-gen-better-python/internal/utils"
 	"github.com/sqlc-dev/plugin-sdk-go/plugin"
 	"github.com/sqlc-dev/plugin-sdk-go/sdk"
 )
@@ -105,7 +104,7 @@ func PostgresTypeToPython(req *plugin.GenerateRequest, config *config.Config, pl
 			columnRelation.Schema = req.Catalog.DefaultSchema
 		}
 		for _, schema := range req.Catalog.Schemas {
-			if schema.Name == utils.PgCatalog || schema.Name == utils.InformationSchema {
+			if schema.Name == PgCatalog || schema.Name == InformationSchema {
 				continue
 			}
 			if schema.Name != columnRelation.Schema {

--- a/internal/types/postgresql_test.go
+++ b/internal/types/postgresql_test.go
@@ -1,0 +1,49 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/rayakame/sqlc-gen-better-python/internal/config"
+	"github.com/rayakame/sqlc-gen-better-python/internal/types"
+	"github.com/sqlc-dev/plugin-sdk-go/plugin"
+)
+
+func TestPostgresTypeToPython(t *testing.T) {
+	t.Parallel()
+	req := &plugin.GenerateRequest{
+		Catalog: &plugin.Catalog{
+			DefaultSchema: "public",
+			Schemas: []*plugin.Schema{
+				// The same enum name inside pg_catalog proves system schemas
+				// are skipped during enum resolution.
+				{Name: types.PgCatalog, Enums: []*plugin.Enum{{Name: "test_mood", Vals: []string{"x"}}}},
+				{Name: "public", Enums: []*plugin.Enum{{Name: "test_mood", Vals: []string{"happy"}}}},
+				{Name: "other", Enums: []*plugin.Enum{{Name: "other_mood", Vals: []string{"y"}}}},
+			},
+		},
+	}
+	conf := &config.Config{}
+	cases := []struct {
+		name       string
+		pluginType *plugin.Identifier
+		want       string
+	}{
+		{"builtin int4", &plugin.Identifier{Name: "int4"}, types.Int},
+		{"enum in default schema", &plugin.Identifier{Name: "test_mood"}, "enums.TestMood"},
+		{"enum in named schema", &plugin.Identifier{Schema: "other", Name: "other_mood"}, "enums.OtherOtherMood"},
+		{
+			"system-schema qualified enum is not resolved",
+			&plugin.Identifier{Schema: types.PgCatalog, Name: "test_mood"},
+			types.Any,
+		},
+		{"unknown type", &plugin.Identifier{Name: "geometry"}, types.Any},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := types.PostgresTypeToPython(req, conf, tc.pluginType); got != tc.want {
+				t.Errorf("PostgresTypeToPython(%+v) = %q, want %q", tc.pluginType, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -7,20 +7,16 @@ import (
 	"github.com/sqlc-dev/plugin-sdk-go/plugin"
 )
 
-const (
-	tableUsers   = "users"
-	schemaPublic = "public"
-)
-
 func TestToPtr(t *testing.T) {
 	t.Parallel()
 	value := "hello"
 	ptr := utils.ToPtr(value)
-	if ptr == nil || *ptr != value {
-		t.Fatalf("ToPtr(%q) = %v, want pointer to %q", value, ptr, value)
+	if *ptr != value {
+		t.Fatalf("ToPtr(%q) points at %q, want %q", value, *ptr, value)
 	}
-	if ptr == &value {
-		t.Fatal("ToPtr must return a pointer to a copy, not to the argument")
+	*ptr = "changed"
+	if value != "hello" {
+		t.Fatal("ToPtr must return a pointer to a copy; mutating it changed the original")
 	}
 }
 
@@ -36,64 +32,78 @@ func TestSameTableName(t *testing.T) {
 		{
 			name: "nil first table",
 			table2: &plugin.Identifier{
-				Name: tableUsers,
+				Name: "users",
 			},
-			defaultSchema: schemaPublic,
+			defaultSchema: "public",
 			want:          false,
 		},
 		{
 			name: "nil second table",
 			table1: &plugin.Identifier{
-				Name: tableUsers,
+				Name: "users",
 			},
-			defaultSchema: schemaPublic,
+			defaultSchema: "public",
 			want:          false,
 		},
 		{
 			name:          "both nil",
-			defaultSchema: schemaPublic,
+			defaultSchema: "public",
 			want:          false,
 		},
 		{
 			name:          "equal fully qualified",
-			table1:        &plugin.Identifier{Catalog: "db", Schema: schemaPublic, Name: tableUsers},
-			table2:        &plugin.Identifier{Catalog: "db", Schema: schemaPublic, Name: tableUsers},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Catalog: "db", Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Catalog: "db", Schema: "public", Name: "users"},
+			defaultSchema: "public",
 			want:          true,
 		},
 		{
 			name:          "empty schema falls back to default on first",
-			table1:        &plugin.Identifier{Name: tableUsers},
-			table2:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Name: "users"},
+			table2:        &plugin.Identifier{Schema: "public", Name: "users"},
+			defaultSchema: "public",
 			want:          true,
 		},
 		{
 			name:          "empty schema falls back to default on second",
-			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
-			table2:        &plugin.Identifier{Name: tableUsers},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Name: "users"},
+			defaultSchema: "public",
 			want:          true,
 		},
 		{
+			name:          "empty default schema with both schemas empty",
+			table1:        &plugin.Identifier{Name: "users"},
+			table2:        &plugin.Identifier{Name: "users"},
+			defaultSchema: "",
+			want:          true,
+		},
+		{
+			name:          "catalog has no default fallback",
+			table1:        &plugin.Identifier{Catalog: "db", Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Schema: "public", Name: "users"},
+			defaultSchema: "public",
+			want:          false,
+		},
+		{
 			name:          "different schemas",
-			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
-			table2:        &plugin.Identifier{Schema: "audit", Name: tableUsers},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Schema: "audit", Name: "users"},
+			defaultSchema: "public",
 			want:          false,
 		},
 		{
 			name:          "different catalogs",
-			table1:        &plugin.Identifier{Catalog: "db1", Schema: schemaPublic, Name: tableUsers},
-			table2:        &plugin.Identifier{Catalog: "db2", Schema: schemaPublic, Name: tableUsers},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Catalog: "db1", Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Catalog: "db2", Schema: "public", Name: "users"},
+			defaultSchema: "public",
 			want:          false,
 		},
 		{
 			name:          "different names",
-			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
-			table2:        &plugin.Identifier{Schema: schemaPublic, Name: "orders"},
-			defaultSchema: schemaPublic,
+			table1:        &plugin.Identifier{Schema: "public", Name: "users"},
+			table2:        &plugin.Identifier{Schema: "public", Name: "orders"},
+			defaultSchema: "public",
 			want:          false,
 		},
 	}

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -1,0 +1,108 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/rayakame/sqlc-gen-better-python/internal/utils"
+	"github.com/sqlc-dev/plugin-sdk-go/plugin"
+)
+
+const (
+	tableUsers   = "users"
+	schemaPublic = "public"
+)
+
+func TestToPtr(t *testing.T) {
+	t.Parallel()
+	value := "hello"
+	ptr := utils.ToPtr(value)
+	if ptr == nil || *ptr != value {
+		t.Fatalf("ToPtr(%q) = %v, want pointer to %q", value, ptr, value)
+	}
+	if ptr == &value {
+		t.Fatal("ToPtr must return a pointer to a copy, not to the argument")
+	}
+}
+
+func TestSameTableName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		table1        *plugin.Identifier
+		table2        *plugin.Identifier
+		defaultSchema string
+		want          bool
+	}{
+		{
+			name: "nil first table",
+			table2: &plugin.Identifier{
+				Name: tableUsers,
+			},
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+		{
+			name: "nil second table",
+			table1: &plugin.Identifier{
+				Name: tableUsers,
+			},
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+		{
+			name:          "both nil",
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+		{
+			name:          "equal fully qualified",
+			table1:        &plugin.Identifier{Catalog: "db", Schema: schemaPublic, Name: tableUsers},
+			table2:        &plugin.Identifier{Catalog: "db", Schema: schemaPublic, Name: tableUsers},
+			defaultSchema: schemaPublic,
+			want:          true,
+		},
+		{
+			name:          "empty schema falls back to default on first",
+			table1:        &plugin.Identifier{Name: tableUsers},
+			table2:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
+			defaultSchema: schemaPublic,
+			want:          true,
+		},
+		{
+			name:          "empty schema falls back to default on second",
+			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
+			table2:        &plugin.Identifier{Name: tableUsers},
+			defaultSchema: schemaPublic,
+			want:          true,
+		},
+		{
+			name:          "different schemas",
+			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
+			table2:        &plugin.Identifier{Schema: "audit", Name: tableUsers},
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+		{
+			name:          "different catalogs",
+			table1:        &plugin.Identifier{Catalog: "db1", Schema: schemaPublic, Name: tableUsers},
+			table2:        &plugin.Identifier{Catalog: "db2", Schema: schemaPublic, Name: tableUsers},
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+		{
+			name:          "different names",
+			table1:        &plugin.Identifier{Schema: schemaPublic, Name: tableUsers},
+			table2:        &plugin.Identifier{Schema: schemaPublic, Name: "orders"},
+			defaultSchema: schemaPublic,
+			want:          false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := utils.SameTableName(tc.table1, tc.table2, tc.defaultSchema); got != tc.want {
+				t.Errorf("SameTableName(%v, %v, %q) = %v, want %v", tc.table1, tc.table2, tc.defaultSchema, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -1,6 +1,0 @@
-package utils
-
-const (
-	InformationSchema = "information_schema"
-	PgCatalog         = "pg_catalog"
-)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -3,7 +3,7 @@ plugins:
   - name: python
     wasm:
       url: file://sqlc-gen-better-python.wasm
-      sha256: ba4691dcc7cbb3423233b52529aa4afd9a4d1fec36b45348290e76dcb4f61e84
+      sha256: e1f4c72156d44c1c0601f66b7aceda32605552118d434c4d0d0ada400d138114
 sql:
   - schema: test/schema.sql
     queries: test/queries.sql

--- a/test/driver_aiosqlite/sqlc.yaml
+++ b/test/driver_aiosqlite/sqlc.yaml
@@ -3,7 +3,7 @@ plugins:
   - name: python
     wasm:
       url: file://sqlc-gen-better-python.wasm
-      sha256: ba4691dcc7cbb3423233b52529aa4afd9a4d1fec36b45348290e76dcb4f61e84
+      sha256: e1f4c72156d44c1c0601f66b7aceda32605552118d434c4d0d0ada400d138114
 sql:
   - schema: schema.sql
     queries: queries.sql

--- a/test/driver_asyncpg/attrs/test_attrs_classes.py
+++ b/test/driver_asyncpg/attrs/test_attrs_classes.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -34,8 +35,18 @@ import math
 import pytest
 import pytest_asyncio
 
+from test.driver_asyncpg.attrs.classes import enums
 from test.driver_asyncpg.attrs.classes import models
 from test.driver_asyncpg.attrs.classes import queries
+from test.driver_asyncpg.attrs.classes import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -129,6 +140,10 @@ class TestAttrsClasses:
     @pytest_asyncio.fixture(scope="session", loop_scope="session")
     async def queries_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries.Queries:
         return queries.Queries(conn=asyncpg_conn)
+
+    @pytest_asyncio.fixture(scope="session", loop_scope="session")
+    async def queries_enum_override_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries_enum_override.QueriesEnumOverride:
+        return queries_enum_override.QueriesEnumOverride(conn=asyncpg_conn)
 
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(name="TestAttrsClasses::create")
@@ -685,3 +700,116 @@ class TestAttrsClasses:
     )
     async def test_delete_type_override(self, queries_obj: queries.Queries, override_model: models.TestTypeOverride) -> None:
         await queries_obj.delete_type_override(id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::insert_enum")
+    async def test_insert_enum(self, queries_obj: queries.Queries) -> None:
+        await queries_obj.insert_one_test_enum_type(id_=510001, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::get_enum", depends=["TestAttrsClasses::insert_enum"])
+    async def test_get_enum(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=510001)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::get_enum_value", depends=["TestAttrsClasses::get_enum"])
+    async def test_get_enum_value(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=510001)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::insert_enum"])
+    async def test_get_enum_none(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::insert_enum"])
+    async def test_get_enum_value_none(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::get_many_enums", depends=["TestAttrsClasses::get_enum_value"])
+    async def test_get_many_enums(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_many_test_enum_types()
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::get_many_enums"])
+    async def test_delete_enum(self, queries_obj: queries.Queries) -> None:
+        assert await queries_obj.delete_one_test_enum_type(id_=510001) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::insert_enum_override")
+    async def test_insert_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override_obj.insert_enum_override(id_=520001, mood_test="happy")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::insert_enum_override"])
+    async def test_get_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=520001)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::insert_enum_override"])
+    async def test_get_enum_override_none(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::list_enum_override", depends=["TestAttrsClasses::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520001])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        results = queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520001])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction; going
+        # through the conn property also covers its generated accessor.
+        async with queries_enum_override_obj.conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520001: "happy"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsClasses::count_enum_override", depends=["TestAttrsClasses::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        count = await queries_enum_override_obj.count_enum_override_by_moods(dollar_1=[enums.TestMood.HAPPY, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsClasses::count_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520001)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        no_row_queries = queries_enum_override.QueriesEnumOverride(conn=conn)
+        count = await no_row_queries.count_enum_override_by_moods(dollar_1=[enums.TestMood.HAPPY])
+        assert count is None

--- a/test/driver_asyncpg/attrs/test_attrs_functions.py
+++ b/test/driver_asyncpg/attrs/test_attrs_functions.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -33,8 +34,18 @@ import math
 
 import pytest
 
+from test.driver_asyncpg.attrs.functions import enums
 from test.driver_asyncpg.attrs.functions import models
 from test.driver_asyncpg.attrs.functions import queries
+from test.driver_asyncpg.attrs.functions import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -768,3 +779,114 @@ class TestAttrsFunctions:
     )
     async def test_delete_type_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record], override_model: models.TestTypeOverride) -> None:
         await queries.delete_type_override(conn=asyncpg_conn, id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::insert_enum")
+    async def test_insert_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await queries.insert_one_test_enum_type(conn=asyncpg_conn, id_=510002, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::get_enum", depends=["TestAttrsFunctions::insert_enum"])
+    async def test_get_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=510002)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::get_enum_value", depends=["TestAttrsFunctions::get_enum"])
+    async def test_get_enum_value(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=510002)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::insert_enum"])
+    async def test_get_enum_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::insert_enum"])
+    async def test_get_enum_value_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::get_many_enums", depends=["TestAttrsFunctions::get_enum_value"])
+    async def test_get_many_enums(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_many_test_enum_types(conn=asyncpg_conn)
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::get_many_enums"])
+    async def test_delete_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        assert await queries.delete_one_test_enum_type(conn=asyncpg_conn, id_=510002) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::insert_enum_override")
+    async def test_insert_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override.insert_enum_override(conn=asyncpg_conn, id_=520002, mood_test="happy")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::insert_enum_override"])
+    async def test_get_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=520002)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::insert_enum_override"])
+    async def test_get_enum_override_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::list_enum_override", depends=["TestAttrsFunctions::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520002])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        results = queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520002])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with asyncpg_conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520002: "happy"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestAttrsFunctions::count_enum_override", depends=["TestAttrsFunctions::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        count = await queries_enum_override.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[enums.TestMood.HAPPY, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await queries_enum_override.count_enum_override_by_moods(conn=conn, dollar_1=[enums.TestMood.HAPPY])
+        assert count is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestAttrsFunctions::count_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520002)

--- a/test/driver_asyncpg/dataclass/test_dataclass_classes.py
+++ b/test/driver_asyncpg/dataclass/test_dataclass_classes.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -35,8 +36,18 @@ import math
 import pytest
 import pytest_asyncio
 
+from test.driver_asyncpg.dataclass.classes import enums
 from test.driver_asyncpg.dataclass.classes import models
 from test.driver_asyncpg.dataclass.classes import queries
+from test.driver_asyncpg.dataclass.classes import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -130,6 +141,10 @@ class TestDataclassClasses:
     @pytest_asyncio.fixture(scope="session", loop_scope="session")
     async def queries_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries.Queries:
         return queries.Queries(conn=asyncpg_conn)
+
+    @pytest_asyncio.fixture(scope="session", loop_scope="session")
+    async def queries_enum_override_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries_enum_override.QueriesEnumOverride:
+        return queries_enum_override.QueriesEnumOverride(conn=asyncpg_conn)
 
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(name="TestDataclassClasses::create")
@@ -700,3 +715,118 @@ class TestDataclassClasses:
     )
     async def test_delete_type_override(self, queries_obj: queries.Queries, override_model: models.TestTypeOverride) -> None:
         await queries_obj.delete_type_override(id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::insert_enum")
+    async def test_insert_enum(self, queries_obj: queries.Queries) -> None:
+        await queries_obj.insert_one_test_enum_type(id_=510003, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::get_enum", depends=["TestDataclassClasses::insert_enum"])
+    async def test_get_enum(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=510003)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::get_enum_value", depends=["TestDataclassClasses::get_enum"])
+    async def test_get_enum_value(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=510003)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::insert_enum"])
+    async def test_get_enum_none(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::insert_enum"])
+    async def test_get_enum_value_none(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::get_many_enums", depends=["TestDataclassClasses::get_enum_value"])
+    async def test_get_many_enums(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_many_test_enum_types()
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::get_many_enums"])
+    async def test_delete_enum(self, queries_obj: queries.Queries) -> None:
+        assert await queries_obj.delete_one_test_enum_type(id_=510003) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::insert_enum_override")
+    async def test_insert_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override_obj.insert_enum_override(id_=520003, mood_test="happy")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::insert_enum_override"])
+    async def test_get_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=520003)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::insert_enum_override"])
+    async def test_get_enum_override_none(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::list_enum_override", depends=["TestDataclassClasses::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520003])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        results = queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520003])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction; going
+        # through the conn property also covers its generated accessor.
+        async with queries_enum_override_obj.conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520003: "happy"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassClasses::count_enum_override", depends=["TestDataclassClasses::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        count = await queries_enum_override_obj.count_enum_override_by_moods(dollar_1=[enums.TestMood.HAPPY, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassClasses::count_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # count_enum_override_by_moods asserts exact counts; remove the row so
+        # later suites against the shared database start clean.
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520003)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        no_row_queries = queries_enum_override.QueriesEnumOverride(conn=conn)
+        count = await no_row_queries.count_enum_override_by_moods(dollar_1=[enums.TestMood.HAPPY])
+        assert count is None

--- a/test/driver_asyncpg/dataclass/test_dataclass_functions.py
+++ b/test/driver_asyncpg/dataclass/test_dataclass_functions.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -34,11 +35,21 @@ import math
 
 import pytest
 
+from test.driver_asyncpg.dataclass.functions import enums
 from test.driver_asyncpg.dataclass.functions import models
 from test.driver_asyncpg.dataclass.functions import queries
+from test.driver_asyncpg.dataclass.functions import queries_enum_override
 from test.driver_asyncpg.dataclass.functions import queries_invalid_identifiers
 
 INVALID_IDENTIFIER_ID = 606060
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -812,3 +823,116 @@ class TestDataclassFunctions:
     @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_third_party_stat"])
     async def test_get_third_party_stat_not_found(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
         assert await queries_invalid_identifiers.get_third_party_stat(conn=asyncpg_conn, id_=INVALID_IDENTIFIER_ID - 1) is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::insert_enum")
+    async def test_insert_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await queries.insert_one_test_enum_type(conn=asyncpg_conn, id_=510004, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::get_enum", depends=["TestDataclassFunctions::insert_enum"])
+    async def test_get_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=510004)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::get_enum_value", depends=["TestDataclassFunctions::get_enum"])
+    async def test_get_enum_value(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=510004)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_enum"])
+    async def test_get_enum_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_enum"])
+    async def test_get_enum_value_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::get_many_enums", depends=["TestDataclassFunctions::get_enum_value"])
+    async def test_get_many_enums(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_many_test_enum_types(conn=asyncpg_conn)
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::get_many_enums"])
+    async def test_delete_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        assert await queries.delete_one_test_enum_type(conn=asyncpg_conn, id_=510004) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::insert_enum_override")
+    async def test_insert_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override.insert_enum_override(conn=asyncpg_conn, id_=520004, mood_test="happy")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_enum_override"])
+    async def test_get_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=520004)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_enum_override"])
+    async def test_get_enum_override_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::list_enum_override", depends=["TestDataclassFunctions::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520004])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        results = queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520004])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with asyncpg_conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520004: "happy"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestDataclassFunctions::count_enum_override", depends=["TestDataclassFunctions::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        count = await queries_enum_override.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[enums.TestMood.HAPPY, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await queries_enum_override.count_enum_override_by_moods(conn=conn, dollar_1=[enums.TestMood.HAPPY])
+        assert count is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestDataclassFunctions::count_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # count_enum_override_by_moods asserts exact counts; remove the row so
+        # later suites against the shared database start clean.
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520004)

--- a/test/driver_asyncpg/msgspec/test_msgspec_classes.py
+++ b/test/driver_asyncpg/msgspec/test_msgspec_classes.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -35,8 +36,18 @@ import math
 import pytest
 import pytest_asyncio
 
+from test.driver_asyncpg.msgspec.classes import enums
 from test.driver_asyncpg.msgspec.classes import models
 from test.driver_asyncpg.msgspec.classes import queries
+from test.driver_asyncpg.msgspec.classes import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -700,3 +711,122 @@ class TestMsgspecClasses:
     )
     async def test_delete_type_override(self, queries_obj: queries.Queries, override_model: models.TestTypeOverride) -> None:
         await queries_obj.delete_type_override(id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::insert_enum")
+    async def test_insert_enum(self, queries_obj: queries.Queries) -> None:
+        await queries_obj.insert_one_test_enum_type(id_=510005, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::get_enum", depends=["TestMsgspecClasses::insert_enum"])
+    async def test_get_enum(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=510005)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::get_enum_value", depends=["TestMsgspecClasses::get_enum"])
+    async def test_get_enum_value(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=510005)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::insert_enum"])
+    async def test_get_enum_none(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::insert_enum"])
+    async def test_get_enum_value_none(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::get_many_enums", depends=["TestMsgspecClasses::get_enum_value"])
+    async def test_get_many_enums(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_many_test_enum_types()
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::get_many_enums"])
+    async def test_delete_enum(self, queries_obj: queries.Queries) -> None:
+        assert await queries_obj.delete_one_test_enum_type(id_=510005) == 1
+
+    @pytest_asyncio.fixture(scope="session", loop_scope="session")
+    async def queries_enum_override_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries_enum_override.QueriesEnumOverride:
+        return queries_enum_override.QueriesEnumOverride(conn=asyncpg_conn)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::insert_enum_override")
+    async def test_insert_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override_obj.insert_enum_override(id_=520005, mood_test="sad")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::insert_enum_override"])
+    async def test_get_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=520005)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "sad"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::insert_enum_override"])
+    async def test_get_enum_override_none(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::list_enum_override", depends=["TestMsgspecClasses::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520005])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "sad"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        results = queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520005])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction; going
+        # through the conn property also covers its generated accessor.
+        async with queries_enum_override_obj.conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520005: "sad"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestMsgspecClasses::count_enum_override", depends=["TestMsgspecClasses::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # No HAPPY in the list: other suites may leave happy rows behind and
+        # would break the exact count.
+        count = await queries_enum_override_obj.count_enum_override_by_moods(dollar_1=[enums.TestMood.SAD, enums.TestMood.OK])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecClasses::count_enum_override"])
+    async def test_cleanup_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520005)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        no_row_queries = queries_enum_override.QueriesEnumOverride(conn=conn)
+        count = await no_row_queries.count_enum_override_by_moods(dollar_1=[enums.TestMood.SAD])
+        assert count is None

--- a/test/driver_asyncpg/msgspec/test_msgspec_functions.py
+++ b/test/driver_asyncpg/msgspec/test_msgspec_functions.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -39,6 +40,14 @@ from test.driver_asyncpg.msgspec.functions import models
 from test.driver_asyncpg.msgspec.functions import queries
 from test.driver_asyncpg.msgspec.functions import queries_copy_override
 from test.driver_asyncpg.msgspec.functions import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -787,6 +796,18 @@ class TestMsgspecFunctions:
         assert mood is enums.TestMood.HAPPY
 
     @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum"])
+    async def test_get_enum_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum"])
+    async def test_get_enum_value_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(name="TestMsgspecFunctions::get_many_enums", depends=["TestMsgspecFunctions::get_enum_value"])
     async def test_get_many_enums(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
         result = await queries.get_many_test_enum_types(conn=asyncpg_conn)
@@ -814,6 +835,12 @@ class TestMsgspecFunctions:
         assert mood == "happy"
 
     @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum_override"])
+    async def test_get_enum_override_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(name="TestMsgspecFunctions::list_enum_override", depends=["TestMsgspecFunctions::insert_enum_override"])
     async def test_list_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
         # :many with an array parameter: the Sequence must pass both pyright
@@ -824,9 +851,33 @@ class TestMsgspecFunctions:
 
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        results = queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[434343])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with asyncpg_conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {434343: "happy"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum_override"])
+    async def test_list_enum_override_by_ids_empty(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        rows = await queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[987654321])
+        assert rows == []
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum_override"])
     async def test_count_enum_override_by_moods(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
         count = await queries_enum_override.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[enums.TestMood.HAPPY, enums.TestMood.SAD])
         assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_by_moods_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await queries_enum_override.count_enum_override_by_moods(conn=conn, dollar_1=[enums.TestMood.HAPPY])
+        assert count is None
 
     @pytest.mark.asyncio(loop_scope="session")
     @pytest.mark.dependency(name="TestMsgspecFunctions::copy_override")
@@ -849,3 +900,15 @@ class TestMsgspecFunctions:
         await queries_copy_override.delete_copy_override_rows(conn=asyncpg_conn)
         count = await queries_copy_override.count_copy_override_rows(conn=asyncpg_conn)
         assert count == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestMsgspecFunctions::insert_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # Later suites count test_enum_override rows by mood; drop this one.
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 434343)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_copy_override_rows_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await queries_copy_override.count_copy_override_rows(conn=conn)
+        assert count is None

--- a/test/driver_asyncpg/omit_tc/test_omit_typechecking_runtime.py
+++ b/test/driver_asyncpg/omit_tc/test_omit_typechecking_runtime.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2025 Rayakame
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Runtime coverage for the omit_typechecking_block query modules.
+
+The generated code must behave exactly like the regular variants even though
+all imports and type aliases execute at module level. These tests exercise
+the query functions and the QueryResults helper (both the await path and the
+cursor-based async-for path) of the classes and functions packages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+
+import pytest
+import pytest_asyncio
+
+from test.driver_asyncpg.omit_tc.classes import enums as classes_enums
+from test.driver_asyncpg.omit_tc.classes import models as classes_models
+from test.driver_asyncpg.omit_tc.classes import queries_enum_override as classes_queries
+from test.driver_asyncpg.omit_tc.functions import enums as functions_enums
+from test.driver_asyncpg.omit_tc.functions import models as functions_models
+from test.driver_asyncpg.omit_tc.functions import queries_enum_override as functions_queries
+
+if typing.TYPE_CHECKING:
+    import asyncpg
+
+# Ids reserved for this file; all suites share one database sequentially, so
+# every enum_override chain uses unique ids and deletes its rows at the end.
+CLASSES_IDS: typing.Final[tuple[int, int]] = (510008, 520008)
+FUNCTIONS_IDS: typing.Final[tuple[int, int]] = (510009, 520009)
+MISSING_ID: typing.Final[int] = 987654321
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestOmitTcClasses:
+    @pytest_asyncio.fixture(scope="session", loop_scope="session")
+    async def queries_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> classes_queries.QueriesEnumOverride:
+        return classes_queries.QueriesEnumOverride(conn=asyncpg_conn)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcClasses::insert_enum_override")
+    async def test_insert_enum_override(self, queries_obj: classes_queries.QueriesEnumOverride) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_obj.insert_enum_override(id_=CLASSES_IDS[0], mood_test="happy")
+        await queries_obj.insert_enum_override(id_=CLASSES_IDS[1], mood_test="sad")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcClasses::get_enum_override", depends=["TestOmitTcClasses::insert_enum_override"])
+    async def test_get_enum_override_mood(self, queries_obj: classes_queries.QueriesEnumOverride) -> None:
+        mood = await queries_obj.get_enum_override_mood(id_=CLASSES_IDS[0])
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_get_enum_override_mood_not_found(self, queries_obj: classes_queries.QueriesEnumOverride) -> None:
+        assert await queries_obj.get_enum_override_mood(id_=MISSING_ID) is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcClasses::list_enum_override", depends=["TestOmitTcClasses::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, queries_obj: classes_queries.QueriesEnumOverride) -> None:
+        # Awaiting the QueryResults object fetches all rows in one go.
+        rows = await queries_obj.list_enum_override_by_ids(dollar_1=list(CLASSES_IDS))
+        assert all(isinstance(row, classes_models.TestEnumOverride) for row in rows)
+        assert {row.id_: row.mood_test for row in rows} == {CLASSES_IDS[0]: "happy", CLASSES_IDS[1]: "sad"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcClasses::iterate_enum_override", depends=["TestOmitTcClasses::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(
+        self,
+        queries_obj: classes_queries.QueriesEnumOverride,
+        asyncpg_conn: asyncpg.Connection[asyncpg.Record],
+    ) -> None:
+        assert queries_obj.conn is asyncpg_conn
+        results = queries_obj.list_enum_override_by_ids(dollar_1=list(CLASSES_IDS))
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with queries_obj.conn.transaction():
+            async for row in results:
+                assert isinstance(row, classes_models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {CLASSES_IDS[0]: "happy", CLASSES_IDS[1]: "sad"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcClasses::count_enum_override", depends=["TestOmitTcClasses::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, queries_obj: classes_queries.QueriesEnumOverride) -> None:
+        count = await queries_obj.count_enum_override_by_moods(dollar_1=[classes_enums.TestMood.HAPPY, classes_enums.TestMood.SAD])
+        assert count == len(CLASSES_IDS)
+        assert await queries_obj.count_enum_override_by_moods(dollar_1=[classes_enums.TestMood.VALUE_24H]) == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        stub_queries_obj = classes_queries.QueriesEnumOverride(conn=conn)
+        count = await stub_queries_obj.count_enum_override_by_moods(dollar_1=[classes_enums.TestMood.HAPPY])
+        assert count is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestOmitTcClasses::insert_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # count_enum_override_by_moods asserts exact counts; remove the rows so
+        # later suites against the shared database start clean.
+        for row_id in CLASSES_IDS:
+            await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", row_id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestOmitTcFunctions:
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcFunctions::insert_enum_override")
+    async def test_insert_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await functions_queries.insert_enum_override(conn=asyncpg_conn, id_=FUNCTIONS_IDS[0], mood_test="happy")
+        await functions_queries.insert_enum_override(conn=asyncpg_conn, id_=FUNCTIONS_IDS[1], mood_test="sad")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcFunctions::get_enum_override", depends=["TestOmitTcFunctions::insert_enum_override"])
+    async def test_get_enum_override_mood(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await functions_queries.get_enum_override_mood(conn=asyncpg_conn, id_=FUNCTIONS_IDS[0])
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "happy"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_get_enum_override_mood_not_found(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        assert await functions_queries.get_enum_override_mood(conn=asyncpg_conn, id_=MISSING_ID) is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcFunctions::list_enum_override", depends=["TestOmitTcFunctions::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # Awaiting the QueryResults object fetches all rows in one go.
+        rows = await functions_queries.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=list(FUNCTIONS_IDS))
+        assert all(isinstance(row, functions_models.TestEnumOverride) for row in rows)
+        assert {row.id_: row.mood_test for row in rows} == {FUNCTIONS_IDS[0]: "happy", FUNCTIONS_IDS[1]: "sad"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcFunctions::iterate_enum_override", depends=["TestOmitTcFunctions::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        results = functions_queries.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=list(FUNCTIONS_IDS))
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with asyncpg_conn.transaction():
+            async for row in results:
+                assert isinstance(row, functions_models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {FUNCTIONS_IDS[0]: "happy", FUNCTIONS_IDS[1]: "sad"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestOmitTcFunctions::count_enum_override", depends=["TestOmitTcFunctions::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        count = await functions_queries.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[functions_enums.TestMood.HAPPY, functions_enums.TestMood.SAD])
+        assert count == len(FUNCTIONS_IDS)
+        assert await functions_queries.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[functions_enums.TestMood.VALUE_24H]) == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await functions_queries.count_enum_override_by_moods(conn=conn, dollar_1=[functions_enums.TestMood.HAPPY])
+        assert count is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestOmitTcFunctions::insert_enum_override"])
+    async def test_delete_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # count_enum_override_by_moods asserts exact counts; remove the rows so
+        # later suites against the shared database start clean.
+        for row_id in FUNCTIONS_IDS:
+            await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", row_id)

--- a/test/driver_asyncpg/pydantic/test_pydantic_classes.py
+++ b/test/driver_asyncpg/pydantic/test_pydantic_classes.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -35,8 +36,18 @@ import math
 import pytest
 import pytest_asyncio
 
+from test.driver_asyncpg.pydantic.classes import enums
 from test.driver_asyncpg.pydantic.classes import models
 from test.driver_asyncpg.pydantic.classes import queries
+from test.driver_asyncpg.pydantic.classes import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -700,3 +711,122 @@ class TestPydanticClasses:
     )
     async def test_delete_type_override(self, queries_obj: queries.Queries, override_model: models.TestTypeOverride) -> None:
         await queries_obj.delete_type_override(id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::insert_enum")
+    async def test_insert_enum(self, queries_obj: queries.Queries) -> None:
+        await queries_obj.insert_one_test_enum_type(id_=510006, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::get_enum", depends=["TestPydanticClasses::insert_enum"])
+    async def test_get_enum(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=510006)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::get_enum_value", depends=["TestPydanticClasses::get_enum"])
+    async def test_get_enum_value(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=510006)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::insert_enum"])
+    async def test_get_enum_none(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_one_test_enum_type(id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::insert_enum"])
+    async def test_get_enum_value_none(self, queries_obj: queries.Queries) -> None:
+        mood = await queries_obj.get_one_test_enum_value(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::get_many_enums", depends=["TestPydanticClasses::get_enum_value"])
+    async def test_get_many_enums(self, queries_obj: queries.Queries) -> None:
+        result = await queries_obj.get_many_test_enum_types()
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::get_many_enums"])
+    async def test_delete_enum(self, queries_obj: queries.Queries) -> None:
+        assert await queries_obj.delete_one_test_enum_type(id_=510006) == 1
+
+    @pytest_asyncio.fixture(scope="session", loop_scope="session")
+    async def queries_enum_override_obj(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> queries_enum_override.QueriesEnumOverride:
+        return queries_enum_override.QueriesEnumOverride(conn=asyncpg_conn)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::insert_enum_override")
+    async def test_insert_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override_obj.insert_enum_override(id_=520006, mood_test="24h")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::insert_enum_override"])
+    async def test_get_enum_override(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=520006)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "24h"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::insert_enum_override"])
+    async def test_get_enum_override_none(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        mood = await queries_enum_override_obj.get_enum_override_mood(id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::list_enum_override", depends=["TestPydanticClasses::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520006])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "24h"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        results = queries_enum_override_obj.list_enum_override_by_ids(dollar_1=[520006])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction; going
+        # through the conn property also covers its generated accessor.
+        async with queries_enum_override_obj.conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520006: "24h"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticClasses::count_enum_override", depends=["TestPydanticClasses::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, queries_enum_override_obj: queries_enum_override.QueriesEnumOverride) -> None:
+        # No HAPPY in the list: other suites may leave happy rows behind and
+        # would break the exact count.
+        count = await queries_enum_override_obj.count_enum_override_by_moods(dollar_1=[enums.TestMood.VALUE_24H, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticClasses::count_enum_override"])
+    async def test_cleanup_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520006)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        no_row_queries = queries_enum_override.QueriesEnumOverride(conn=conn)
+        count = await no_row_queries.count_enum_override_by_moods(dollar_1=[enums.TestMood.VALUE_24H])
+        assert count is None

--- a/test/driver_asyncpg/pydantic/test_pydantic_functions.py
+++ b/test/driver_asyncpg/pydantic/test_pydantic_functions.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import asyncio
 import collections.abc
 import datetime
 import decimal
@@ -34,8 +35,18 @@ import math
 
 import pytest
 
+from test.driver_asyncpg.pydantic.functions import enums
 from test.driver_asyncpg.pydantic.functions import models
 from test.driver_asyncpg.pydantic.functions import queries
+from test.driver_asyncpg.pydantic.functions import queries_enum_override
+
+
+class _NoRowConn:
+    # `SELECT count(*)` always returns exactly one row, so the generated
+    # not-found branch of the count queries needs a connection stub that
+    # misses.
+    async def fetchrow(self, _query: str, *_args: object) -> None:
+        await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -772,3 +783,116 @@ class TestPydanticFunctions:
     )
     async def test_delete_type_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record], override_model: models.TestTypeOverride) -> None:
         await queries.delete_type_override(conn=asyncpg_conn, id_=override_model.id_)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_digit_leading_enum_constant_is_member(self) -> None:
+        # "_24H" or "_HIDDEN" names would be treated as private by enum.
+        assert enums.TestMood.VALUE_24H.value == "24h"
+        assert enums.TestMood("24h") is enums.TestMood.VALUE_24H
+        assert enums.TestMood.VALUE__HIDDEN.value == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::insert_enum")
+    async def test_insert_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await queries.insert_one_test_enum_type(conn=asyncpg_conn, id_=510007, mood=enums.TestMood.HAPPY, maybe_mood=None)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::get_enum", depends=["TestPydanticFunctions::insert_enum"])
+    async def test_get_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=510007)
+        assert result is not None
+        assert isinstance(result.mood, enums.TestMood)
+        assert result.mood is enums.TestMood.HAPPY
+        assert result.maybe_mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::get_enum_value", depends=["TestPydanticFunctions::get_enum"])
+    async def test_get_enum_value(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=510007)
+        assert isinstance(mood, enums.TestMood)
+        assert mood is enums.TestMood.HAPPY
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::insert_enum"])
+    async def test_get_enum_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_one_test_enum_type(conn=asyncpg_conn, id_=987654321)
+        assert result is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::insert_enum"])
+    async def test_get_enum_value_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries.get_one_test_enum_value(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::get_many_enums", depends=["TestPydanticFunctions::get_enum_value"])
+    async def test_get_many_enums(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        result = await queries.get_many_test_enum_types(conn=asyncpg_conn)
+        assert len(result) >= 1
+        assert all(isinstance(row.mood, enums.TestMood) for row in result)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::get_many_enums"])
+    async def test_delete_enum(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        assert await queries.delete_one_test_enum_type(conn=asyncpg_conn, id_=510007) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::insert_enum_override")
+    async def test_insert_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # The overridden parameter is a plain str; the generated code converts
+        # it back to enums.TestMood before it reaches the driver.
+        await queries_enum_override.insert_enum_override(conn=asyncpg_conn, id_=520007, mood_test="_hidden")
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::insert_enum_override"])
+    async def test_get_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=520007)
+        assert mood is not None
+        assert isinstance(mood, str)
+        assert mood == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::insert_enum_override"])
+    async def test_get_enum_override_none(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        mood = await queries_enum_override.get_enum_override_mood(conn=asyncpg_conn, id_=987654321)
+        assert mood is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::list_enum_override", depends=["TestPydanticFunctions::insert_enum_override"])
+    async def test_list_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # :many with an array parameter: the Sequence must pass both pyright
+        # (QueryResultsArgsType) and the runtime QueryResults plumbing.
+        rows = await queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520007])
+        assert len(rows) == 1
+        assert rows[0].mood_test == "_hidden"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::insert_enum_override"])
+    async def test_iterate_enum_override_by_ids(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        results = queries_enum_override.list_enum_override_by_ids(conn=asyncpg_conn, dollar_1=[520007])
+        seen: dict[int, str] = {}
+        # The cursor-based async-for path requires a transaction.
+        async with asyncpg_conn.transaction():
+            async for row in results:
+                assert isinstance(row, models.TestEnumOverride)
+                seen[row.id_] = row.mood_test
+        assert seen == {520007: "_hidden"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(name="TestPydanticFunctions::count_enum_override", depends=["TestPydanticFunctions::insert_enum_override"])
+    async def test_count_enum_override_by_moods(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        # No HAPPY in the list: other suites may leave happy rows behind and
+        # would break the exact count.
+        count = await queries_enum_override.count_enum_override_by_moods(conn=asyncpg_conn, dollar_1=[enums.TestMood.VALUE__HIDDEN, enums.TestMood.SAD])
+        assert count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_enum_override_no_row(self) -> None:
+        conn = typing.cast("asyncpg.Connection[asyncpg.Record]", _NoRowConn())
+        count = await queries_enum_override.count_enum_override_by_moods(conn=conn, dollar_1=[enums.TestMood.VALUE__HIDDEN])
+        assert count is None
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.dependency(depends=["TestPydanticFunctions::count_enum_override"])
+    async def test_cleanup_enum_override(self, asyncpg_conn: asyncpg.Connection[asyncpg.Record]) -> None:
+        await asyncpg_conn.execute("DELETE FROM test_enum_override WHERE id = $1", 520007)

--- a/test/driver_asyncpg/sqlc.yaml
+++ b/test/driver_asyncpg/sqlc.yaml
@@ -3,7 +3,7 @@ plugins:
   - name: python
     wasm:
       url: file://sqlc-gen-better-python.wasm
-      sha256: ba4691dcc7cbb3423233b52529aa4afd9a4d1fec36b45348290e76dcb4f61e84
+      sha256: e1f4c72156d44c1c0601f66b7aceda32605552118d434c4d0d0ada400d138114
 sql:
   - schema: schema.sql
     queries:

--- a/test/driver_sqlite3/dataclass/test_sqlite3_dataclass_functions.py
+++ b/test/driver_sqlite3/dataclass/test_sqlite3_dataclass_functions.py
@@ -967,11 +967,19 @@ class TestSqlite3DataclassFunctions:
         assert price == OVERRIDE_PRICE
 
     @pytest.mark.dependency(depends=["Sqlite3TestDataclassFunctions::get_override_price"])
+    def test_get_override_price_not_found(self, sqlite3_conn: sqlite3.Connection) -> None:
+        assert queries_override_adapter.get_override_price(conn=sqlite3_conn, id_=434342) is None
+
+    @pytest.mark.dependency(depends=["Sqlite3TestDataclassFunctions::get_override_price"])
     def test_get_override_happened_at(self, sqlite3_conn: sqlite3.Connection) -> None:
         happened_at = queries_override_converter.get_override_happened_at(conn=sqlite3_conn, id_=434343)
         assert happened_at is not None
         assert isinstance(happened_at, datetime.datetime)
         assert happened_at == OVERRIDE_HAPPENED_AT
+
+    @pytest.mark.dependency(depends=["Sqlite3TestDataclassFunctions::get_override_price"])
+    def test_get_override_happened_at_not_found(self, sqlite3_conn: sqlite3.Connection) -> None:
+        assert queries_override_converter.get_override_happened_at(conn=sqlite3_conn, id_=434342) is None
 
     @pytest.mark.dependency(name="Sqlite3TestDataclassFunctions::insert_case_row")
     def test_insert_case_row(self, sqlite3_conn: sqlite3.Connection) -> None:
@@ -988,6 +996,10 @@ class TestSqlite3DataclassFunctions:
         assert isinstance(row.prec_dec, decimal.Decimal)
         assert row.prec_dec == CASE_DEC
 
+    @pytest.mark.dependency(depends=["Sqlite3TestDataclassFunctions::insert_case_row"])
+    def test_get_case_row_not_found(self, sqlite3_conn: sqlite3.Connection) -> None:
+        assert queries_case.get_case_row(conn=sqlite3_conn, id_=515150) is None
+
     @pytest.mark.dependency(name="Sqlite3TestDataclassFunctions::insert_reserved_arg")
     def test_insert_reserved_arg(self, sqlite3_conn: sqlite3.Connection) -> None:
         # The column is literally named "conn"; the generated parameter must
@@ -998,6 +1010,10 @@ class TestSqlite3DataclassFunctions:
     def test_get_reserved_arg(self, sqlite3_conn: sqlite3.Connection) -> None:
         found_id = queries_case.get_reserved_arg(conn=sqlite3_conn, conn_2="reserved-arg-value")
         assert found_id == RESERVED_ARG_ID
+
+    @pytest.mark.dependency(depends=["Sqlite3TestDataclassFunctions::insert_reserved_arg"])
+    def test_get_reserved_arg_not_found(self, sqlite3_conn: sqlite3.Connection) -> None:
+        assert queries_case.get_reserved_arg(conn=sqlite3_conn, conn_2="missing-reserved-arg-value") is None
 
     @pytest.mark.dependency(name="Sqlite3TestDataclassFunctions::insert_unknown_override")
     def test_insert_unknown_override(self, sqlite3_conn: sqlite3.Connection) -> None:

--- a/test/driver_sqlite3/sqlc.yaml
+++ b/test/driver_sqlite3/sqlc.yaml
@@ -3,7 +3,7 @@ plugins:
   - name: python
     wasm:
       url: file://sqlc-gen-better-python.wasm
-      sha256: ba4691dcc7cbb3423233b52529aa4afd9a4d1fec36b45348290e76dcb4f61e84
+      sha256: e1f4c72156d44c1c0601f66b7aceda32605552118d434c4d0d0ada400d138114
 sql:
   - schema: schema.sql
     queries:


### PR DESCRIPTION
Python:
- Port the enum and enum_override test block from the msgspec functions suite to all seven other asyncpg suites (unique row ids per suite plus cleanup tests, since all suites share one database sequentially)
- Add a runtime suite for the omit_tc packages and cover the remaining sqlite3 dataclass not-found branches
- Cover the QueryResults iteration path, not-found returns and the row-is-None count branches (the latter via a typed fake connection, the only way to reach them since SELECT count(*) always returns a row)
- Coverage is back to 100% (8116 statements, 636 branches, 0 missed) with 1426 tests passing

Coverage combining:
- codecov.yml: go and python flags with carryforward and per-flag project/patch statuses
- ci.yml: go-test runs with -coverprofile -coverpkg=./internal/... and uploads with the go flag; the python upload gets the python flag
- README: per-flag coverage badges next to the overall badge

Go:
- First per-file unit tests: internal/utils/common_test.go covers ToPtr and every branch of SameTableName (package at 100%)
- Consolidate constants: the SQL system-schema names move from utils/constants.go into types/constants.go next to the Python type names; utils keeps only its helper functions
- Exclude exhaustruct on _test.go files: partially initialized fixture structs are the point of table-driven tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved PostgreSQL enum generation/handling, including digit-leading enum constants and full override support (insert/get/list/iterate/count/delete), with correct nullable behavior.
  - PostgreSQL system schemas are no longer emitted as generated models or enums.
  - Added a Go coverage badge alongside the existing Python coverage badge.

- **Bug Fixes**
  - Correctly returns `None`/empty outcomes for missing or non-matching records across generated query interfaces.

- **Tests**
  - Expanded async PostgreSQL, SQLite, and unit test coverage for enums and schema-skipping behavior.

- **Chores / CI**
  - Refined coverage reporting in CI/Codecov with per-language flags and updated plugin checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->