### PR TITLE
docs: add Hextra documentation site scaffold

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,9 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Least privilege plus the tokens the Pages deployment needs.
+# Build needs only read; the Pages write tokens are scoped to the deploy job.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Never cancel an in-progress deployment; let it finish.
 concurrency:
@@ -32,13 +30,19 @@ jobs:
     steps:
       - name: Install Hugo (extended)
         run: |
-          wget -O /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
+          wget -O /tmp/hugo.deb "${base}/${deb}"
+          wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
+          sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
+          echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
           sudo dpkg -i /tmp/hugo.deb
 
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -60,9 +64,13 @@ jobs:
 
   deploy:
     needs: build
-    # Pull requests only build (above) to validate; deployment is main-only.
-    if: github.event_name != 'pull_request'
+    # Deploy only on a real push/dispatch to main, never on pull requests.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,15 +45,13 @@ jobs:
         with:
           go-version-file: docs/go.mod
 
-      - name: Configure Pages
-        id: pages
-        uses: actions/configure-pages@v5
-
+      # baseURL comes from hugo.yaml, so the build has no dependency on Pages
+      # being enabled - PR builds validate without any repo setup.
       - name: Build with Hugo
         working-directory: docs
         env:
           HUGO_ENVIRONMENT: production
-        run: hugo --minify --gc --baseURL "${{ steps.pages.outputs.base_url }}/"
+        run: hugo --minify --gc
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -69,6 +67,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # enablement turns Pages on automatically the first time, so no manual
+      # "Settings -> Pages -> GitHub Actions" step is needed.
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Least privilege plus the tokens the Pages deployment needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel an in-progress deployment; let it finish.
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.164.0
+    steps:
+      - name: Install Hugo (extended)
+        run: |
+          wget -O /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i /tmp/hugo.deb
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: docs/go.mod
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Hugo
+        working-directory: docs
+        env:
+          HUGO_ENVIRONMENT: production
+        run: hugo --minify --gc --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public
+
+  deploy:
+    needs: build
+    # Pull requests only build (above) to validate; deployment is main-only.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,8 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write # deploy-pages publishes the built site to GitHub Pages
+      id-token: write # deploy-pages uses OIDC to verify the deployment origin
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A WASM plugin for SQLC allowing the generation of Python code.
 The generated code requires **Python 3.12 or newer** (it uses PEP 695 type
 aliases and generics, and `enum.StrEnum`).
 
+**Documentation: https://rayakame.github.io/sqlc-gen-better-python/**
+(The docs site is new; some feature reference still lives in this README below
+while it is ported over.)
+
 
 > [!NOTE]  
 > Every Release before `v1.0.0`, including this one is an beta release. 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The generated code requires **Python 3.12 or newer** (it uses PEP 695 type
 aliases and generics, and `enum.StrEnum`).
 
 **Documentation: https://rayakame.github.io/sqlc-gen-better-python/**
-(The docs site is new; some feature reference still lives in this README below
-while it is ported over.)
+(The docs site is new; some feature references still live in this README below
+while they are ported over.)
 
 
 > [!NOTE]  

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+# Hugo build output and caches
+/public/
+/resources/_gen/
+.hugo_build.lock

--- a/docs/archetypes/default.md
+++ b/docs/archetypes/default.md
@@ -1,0 +1,5 @@
+---
+date: '{{ .Date }}'
+draft: true
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+---

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -16,7 +16,7 @@ layout: hextra-home
 
 <div class="hx-mb-12">
 {{< hextra/hero-subtitle >}}
-  A sqlc plugin that generates modern, fully typed Python database&nbsp;<br class="sm:hx-block hx-hidden" />code from plain SQL &mdash; models plus async query functions.
+  A sqlc plugin that generates modern, fully typed Python database&nbsp;<br class="sm:hx-block hx-hidden" />code from plain SQL - models plus async query functions.
 {{< /hextra/hero-subtitle >}}
 </div>
 
@@ -29,7 +29,7 @@ layout: hextra-home
 {{< hextra/feature-grid >}}
   {{< hextra/feature-card
     title="Four model types"
-    subtitle="Generate dataclass, attrs, msgspec, or pydantic models &mdash; pick per codegen block."
+    subtitle="Generate dataclass, attrs, msgspec, or pydantic models - pick per codegen block."
   >}}
   {{< hextra/feature-card
     title="Three drivers"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,54 @@
+---
+title: sqlc-gen-better-python
+layout: hextra-home
+---
+
+{{< hextra/hero-badge >}}
+  <div class="hx-w-2 hx-h-2 hx-rounded-full hx-bg-primary-400"></div>
+  <span>Free, open source, self-hosted</span>
+{{< /hextra/hero-badge >}}
+
+<div class="hx-mt-6 hx-mb-6">
+{{< hextra/hero-headline >}}
+  Type-safe Python from your SQL
+{{< /hextra/hero-headline >}}
+</div>
+
+<div class="hx-mb-12">
+{{< hextra/hero-subtitle >}}
+  A sqlc plugin that generates modern, fully typed Python database&nbsp;<br class="sm:hx-block hx-hidden" />code from plain SQL &mdash; models plus async query functions.
+{{< /hextra/hero-subtitle >}}
+</div>
+
+<div class="hx-mb-6">
+{{< hextra/hero-button text="Get Started" link="docs/getting-started" >}}
+</div>
+
+<div class="hx-mt-6"></div>
+
+{{< hextra/feature-grid >}}
+  {{< hextra/feature-card
+    title="Four model types"
+    subtitle="Generate dataclass, attrs, msgspec, or pydantic models &mdash; pick per codegen block."
+  >}}
+  {{< hextra/feature-card
+    title="Three drivers"
+    subtitle="asyncpg for PostgreSQL, plus aiosqlite and sqlite3 for SQLite."
+  >}}
+  {{< hextra/feature-card
+    title="Strictly typed output"
+    subtitle="Generated code passes pyright strict and ruff, targeting Python 3.12+."
+  >}}
+  {{< hextra/feature-card
+    title="Enums"
+    subtitle="PostgreSQL enums become enum.StrEnum classes, wired through models and queries."
+  >}}
+  {{< hextra/feature-card
+    title="Type overrides & converters"
+    subtitle="Swap a column's Python type, or plug in your own encode/decode functions."
+  >}}
+  {{< hextra/feature-card
+    title="Docstrings"
+    subtitle="Optional google, numpy, or pep257 docstrings on every generated function."
+  >}}
+{{< /hextra/feature-grid >}}

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1,0 +1,25 @@
+---
+title: Documentation
+weight: 1
+prev: /
+next: getting-started
+sidebar:
+  open: true
+---
+
+`sqlc-gen-better-python` is a [sqlc](https://sqlc.dev) plugin that turns your SQL
+schema and queries into modern, fully typed Python database code: models plus
+async query functions, ready to run.
+
+Start with **[Getting Started](getting-started)** for installation and a first
+generate, then explore the individual features.
+
+{{< cards >}}
+  {{< card link="getting-started" title="Getting Started" subtitle="Install the plugin and generate your first models." >}}
+  {{< card link="converters" title="Converters" subtitle="Serialize and deserialize columns with your own functions." >}}
+{{< /cards >}}
+
+{{< callout type="info" >}}
+  These docs are new and growing. More feature pages (model types, drivers,
+  enums, type overrides, docstrings) are being ported from the README.
+{{< /callout >}}

--- a/docs/content/docs/converters.md
+++ b/docs/content/docs/converters.md
@@ -121,5 +121,5 @@ overrides:
 {{< /tabs >}}
 
 A `get_user` query then returns a fully typed `User` (set field and all), and a
-`create_user` query accepts one directly &mdash; the plugin inserts the
+`create_user` query accepts one directly - the plugin inserts the
 `decode_user` / `encode_user` calls for you.

--- a/docs/content/docs/converters.md
+++ b/docs/content/docs/converters.md
@@ -1,0 +1,119 @@
+---
+title: Converters
+weight: 3
+prev: getting-started
+---
+
+A [type override](https://github.com/rayakame/sqlc-gen-better-python#type-overrides)
+replaces a column's Python type, but it converts by *calling that type*
+(`Preferences(value)`), which cannot express JSON or model (de)serialization. A
+**converter** names two of your own functions instead, used whenever the column
+is read from or written to the database.
+
+## Defining a converter
+
+Declare the converter under `converters`, then reference it from an override:
+
+```yaml
+options:
+  # ...
+  converters:
+    - name: prefs
+      py_type:
+        import: myapp.models
+        package: Preferences
+        type: Preferences
+      to_db: myapp.converters.encode_preferences
+      from_db: myapp.converters.decode_preferences
+  overrides:
+    - db_type: jsonb          # every jsonb column
+      converter: prefs
+    - column: users.preferences   # or one specific column
+      converter: prefs
+```
+
+The generated code calls your functions on both sides:
+
+```python
+# read
+preferences = myapp.converters.decode_preferences(row[1])
+# write
+await conn.execute(CREATE_USER, id_, myapp.converters.encode_preferences(preferences))
+```
+
+## Rules
+
+{{< callout type="info" >}}
+  A converter is referenced *by an override*, so it applies to whichever columns
+  that override matches. `converter` replaces `py_type` on the override.
+{{< /callout >}}
+
+- **Both directions are required.** `to_db` and `from_db` are dotted paths to
+  module-level functions; the module is imported and the function called fully
+  qualified, so the names can never collide with generated code.
+- **Wire type.** `to_db` must return the type the column would have had *without*
+  the override (`jsonb` is a `str`, `bytea` a `memoryview`), and `from_db`
+  receives that same type. For an unrecognised SQL type there is no such type, so
+  `to_db` must return one the driver accepts.
+- **Your functions never see `None`.** Nullable columns are guarded, so a SQL
+  `NULL` stays `None` without calling the converter.
+- **List columns convert element-wise.**
+
+## Example: msgspec structs to and from JSON
+
+Because `msgspec.json.decode` needs a `type=` argument and returns `bytes`, you
+wrap it in two small functions that match the wire type of a `jsonb` column
+(`str`):
+
+{{< tabs >}}
+
+  {{< tab name="converters.py" >}}
+```python
+import msgspec
+
+from myapp.models import User
+
+
+def encode_user(value: User) -> str:
+    # jsonb's wire type is str, so decode msgspec's bytes back to str.
+    return msgspec.json.encode(value).decode()
+
+
+def decode_user(value: str) -> User:
+    return msgspec.json.decode(value, type=User)
+```
+  {{< /tab >}}
+
+  {{< tab name="models.py" >}}
+```python
+import msgspec
+
+
+class User(msgspec.Struct):
+    name: str
+    groups: set[str]
+    email: str | None = None
+```
+  {{< /tab >}}
+
+  {{< tab name="sqlc.yaml" >}}
+```yaml
+converters:
+  - name: user
+    py_type:
+      import: myapp.models
+      package: User
+      type: User
+    to_db: myapp.converters.encode_user
+    from_db: myapp.converters.decode_user
+overrides:
+  - db_type: jsonb
+    converter: user
+```
+  {{< /tab >}}
+
+{{< /tabs >}}
+
+A `get_user` query then returns a fully typed `User` (set field and all), and a
+`create_user` query accepts one directly &mdash; the plugin inserts the
+`decode_user` / `encode_user` calls for you.

--- a/docs/content/docs/converters.md
+++ b/docs/content/docs/converters.md
@@ -68,6 +68,7 @@ wrap it in two small functions that match the wire type of a `jsonb` column
 {{< tabs >}}
 
   {{< tab name="converters.py" >}}
+
 ```python
 import msgspec
 
@@ -82,9 +83,11 @@ def encode_user(value: User) -> str:
 def decode_user(value: str) -> User:
     return msgspec.json.decode(value, type=User)
 ```
+
   {{< /tab >}}
 
   {{< tab name="models.py" >}}
+
 ```python
 import msgspec
 
@@ -94,9 +97,11 @@ class User(msgspec.Struct):
     groups: set[str]
     email: str | None = None
 ```
+
   {{< /tab >}}
 
   {{< tab name="sqlc.yaml" >}}
+
 ```yaml
 converters:
   - name: user
@@ -110,6 +115,7 @@ overrides:
   - db_type: jsonb
     converter: user
 ```
+
   {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -1,0 +1,62 @@
+---
+title: Getting Started
+weight: 2
+prev: /docs
+next: converters
+---
+
+## Prerequisites
+
+You need [`sqlc`](https://docs.sqlc.dev/en/latest/overview/install.html) on your
+`PATH`. The generated code targets **Python 3.12 or newer** (it uses PEP 695 type
+aliases and generics, and `enum.StrEnum`).
+
+## Configure the plugin
+
+The plugin is a WASM binary that `sqlc generate` downloads and runs. Point your
+`sqlc.yaml` at a release and select a driver and model type:
+
+```yaml
+# filename: sqlc.yaml
+version: "2"
+plugins:
+  - name: python
+    wasm:
+      url: https://github.com/rayakame/sqlc-gen-better-python/releases/download/v0.5.1/sqlc-gen-better-python.wasm
+      sha256: c7cc470df7625ae3232c2b042060b948180ae784ce3d81c32e8a2c040fe04fa7
+sql:
+  - engine: "postgresql"
+    queries: "query.sql"
+    schema: "schema.sql"
+    codegen:
+      - out: "app/db"
+        plugin: python
+        options:
+          package: "db"
+          emit_init_file: true
+          sql_driver: "asyncpg"
+          model_type: "msgspec"
+```
+
+{{< callout type="warning" >}}
+  Always pin the `sha256` of the release you use &mdash; `sqlc` refuses to run a
+  plugin whose hash does not match. Each release lists its hash.
+{{< /callout >}}
+
+## Generate
+
+Run `sqlc` from the directory containing your `sqlc.yaml`:
+
+```bash
+sqlc generate
+```
+
+This writes a Python package to `out` containing `models.py`, one query module
+per query file, and (when your schema has enums) an `enums.py`.
+
+## Next steps
+
+- Full option reference and driver support: see the
+  [project README](https://github.com/rayakame/sqlc-gen-better-python#configuration-options)
+  while the remaining pages are ported here.
+- Plug in your own serialization with [Converters](converters).

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -39,7 +39,7 @@ sql:
 ```
 
 {{< callout type="warning" >}}
-  Always pin the `sha256` of the release you use &mdash; `sqlc` refuses to run a
+  Always pin the `sha256` of the release you use - `sqlc` refuses to run a
   plugin whose hash does not match. Each release lists its hash.
 {{< /callout >}}
 

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,5 @@
+module github.com/rayakame/sqlc-gen-better-python/docs
+
+go 1.26.5
+
+require github.com/imfing/hextra v0.12.3 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,0 +1,2 @@
+github.com/imfing/hextra v0.12.3 h1:DZHY2rUWYteyzjlHi9r4n7Bb5e2Q+6LXe4C1Dqn0ZjM=
+github.com/imfing/hextra v0.12.3/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -1,0 +1,51 @@
+baseURL: "https://rayakame.github.io/sqlc-gen-better-python/"
+title: sqlc-gen-better-python
+enableRobotsTXT: true
+enableGitInfo: true
+hasCJKLanguage: false
+
+module:
+  imports:
+    - path: github.com/imfing/hextra
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  highlight:
+    noClasses: false
+
+menu:
+  main:
+    - name: Docs
+      pageRef: /docs
+      weight: 1
+    - name: Search
+      weight: 2
+      params:
+        type: search
+    - name: GitHub
+      weight: 3
+      url: "https://github.com/rayakame/sqlc-gen-better-python"
+      params:
+        icon: github
+
+params:
+  description: A sqlc plugin that generates modern, type-safe Python database code from SQL.
+  navbar:
+    displayTitle: true
+    displayLogo: false
+  theme:
+    default: system
+    displayToggle: true
+  search:
+    enable: true
+    type: flexsearch
+    flexsearch:
+      index: content
+  editURL:
+    enable: true
+    base: "https://github.com/rayakame/sqlc-gen-better-python/edit/main/docs/content"
+  footer:
+    displayCopyright: true
+    displayPoweredBy: true


### PR DESCRIPTION
Sets up the base of a real documentation site using **Hugo + [Hextra](https://github.com/imfing/hextra)** — Markdown-authored, MIT-licensed, fully self-hosted on GitHub Pages, and kept in the Go/Hugo toolchain this project already lives in (no Python/pip docs stack).

This is the **walking skeleton**: a live, good-looking site with working nav, search, dark mode, and deploy — not the full content port. Remaining README sections (model types, drivers, enums, type overrides, docstrings) follow page-by-page in later PRs.

## What's here

- **`docs/`** — Hextra pinned via Hugo Modules with its own nested `go.mod`. It's fully isolated from the plugin module: `go build ./...`, `go test ./...`, and golangci-lint don't descend into it (verified).
- **Config** — dark/light toggle (system default), built-in offline FlexSearch, edit-on-GitHub links, GitHub icon in the navbar.
- **Starter content** — home hero + feature grid, docs index, **Getting Started**, and a **Converters** page that shows off callouts, code tabs, and the msgspec↔JSON recipe.
- **`.github/workflows/docs.yml`** — builds on PRs (so future docs PRs are validated) and, on push to `main`, deploys to GitHub Pages via `actions/deploy-pages` (modern flow, no `gh-pages` branch).
- **README** — links to the docs site.

## Verified locally

Built with Hugo extended 0.164.0 using the exact CI command (`hugo --minify --gc --baseURL …`): **13 pages, zero warnings**, hero/tabs/callouts render, FlexSearch index generated.

## One manual step (yours)

After merge, set **Settings → Pages → Source: GitHub Actions** (I can't flip that). The first deploy runs automatically on the merge to `main`; the site will be at **https://rayakame.github.io/sqlc-gen-better-python/**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hugo-powered documentation site with homepage, navigation, and search, including “Documentation” and “Getting Started” pages.
  * Added a dedicated “Converters” guide with detailed rules and examples.
  * Enabled automated publishing of the docs to GitHub Pages via GitHub Actions.
* **Documentation**
  * Updated the README with a Documentation link and noted that some feature reference content is still being ported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->