### PR TITLE
docs: homepage hero polish and per-PR preview deployments

### DIFF
--- a/.github/actions/install-hugo/action.yml
+++ b/.github/actions/install-hugo/action.yml
@@ -1,0 +1,23 @@
+name: Install Hugo (extended)
+description: Download, checksum-verify, and install the Hugo extended .deb package.
+
+inputs:
+  hugo-version:
+    description: The Hugo version to install.
+    required: false
+    default: "0.164.0"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        HUGO_VERSION: ${{ inputs.hugo-version }}
+      run: |
+        deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+        base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
+        wget -O /tmp/hugo.deb "${base}/${deb}"
+        wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
+        sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
+        echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
+        sudo dpkg -i /tmp/hugo.deb

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
+      - ".github/actions/install-hugo/action.yml"
   pull_request:
     types:
       - opened
@@ -16,6 +17,7 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
+      - ".github/actions/install-hugo/action.yml"
   workflow_dispatch:
 
 # Publishing jobs raise this to write on themselves; keep the default read-only.
@@ -31,28 +33,21 @@ concurrency:
 jobs:
   # Production: build the site and publish it to the gh-pages branch root.
   deploy:
+    name: "Deploy docs"
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # contents: write lets the deploy action push the built site to gh-pages.
     permissions:
       contents: write
-    env:
-      HUGO_VERSION: 0.164.0
     steps:
-      - name: Install Hugo (extended)
-        run: |
-          deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-          base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
-          wget -O /tmp/hugo.deb "${base}/${deb}"
-          wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
-          sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
-          echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
-          sudo dpkg -i /tmp/hugo.deb
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Install Hugo (extended)
+        uses: ./.github/actions/install-hugo
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -80,31 +75,26 @@ jobs:
   # PR previews: build with a per-PR baseURL and publish under
   # gh-pages/pr-preview/pr-N; the action removes it when the PR closes.
   preview:
-    if: github.event_name == 'pull_request'
+    name: "Deploy PR preview"
+    # Skip forks: their token is read-only, so a preview push would only fail.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # contents: write publishes the preview to gh-pages; pull-requests: write
+    # lets the action comment the preview URL on the pull request.
     permissions:
       contents: write
       pull-requests: write
-    env:
-      HUGO_VERSION: 0.164.0
     steps:
-      - name: Install Hugo (extended)
-        if: github.event.action != 'closed'
-        run: |
-          deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-          base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
-          wget -O /tmp/hugo.deb "${base}/${deb}"
-          wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
-          sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
-          echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
-          sudo dpkg -i /tmp/hugo.deb
-
       # Always checked out so the deploy action can operate, even on close.
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Install Hugo (extended)
+        if: github.event.action != 'closed'
+        uses: ./.github/actions/install-hugo
 
       - name: Set up Go
         if: github.event.action != 'closed'
@@ -119,7 +109,8 @@ jobs:
         working-directory: docs
         env:
           HUGO_ENVIRONMENT: production
-        run: hugo --minify --gc --baseURL "https://rayakame.github.io/sqlc-gen-better-python/pr-preview/pr-${{ github.event.number }}/"
+          PR_NUMBER: ${{ github.event.number }}
+        run: hugo --minify --gc --baseURL "https://rayakame.github.io/sqlc-gen-better-python/pr-preview/pr-${PR_NUMBER}/"
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,23 +8,33 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yml"
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Build needs only read; the Pages write tokens are scoped to the deploy job.
+# Publishing jobs raise this to write on themselves; keep the default read-only.
 permissions:
   contents: read
 
-# Never cancel an in-progress deployment; let it finish.
+# Serialize per PR (and separately for main) so pushes to the gh-pages branch
+# do not race; never cancel an in-progress deploy.
 concurrency:
-  group: docs-pages
+  group: docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  # Production: build the site and publish it to the gh-pages branch root.
+  deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       HUGO_VERSION: 0.164.0
     steps:
@@ -49,39 +59,71 @@ jobs:
         with:
           go-version-file: docs/go.mod
 
-      # baseURL comes from hugo.yaml, so the build has no dependency on Pages
-      # being enabled - PR builds validate without any repo setup.
+      # baseURL comes from hugo.yaml (the production root).
       - name: Build with Hugo
         working-directory: docs
         env:
           HUGO_ENVIRONMENT: production
         run: hugo --minify --gc
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      # clean-exclude keeps the pr-preview umbrella so a production deploy
+      # never deletes previews of still-open PRs; force: false rebases
+      # instead of force-pushing, tolerating concurrent preview pushes.
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: docs/public
+          branch: gh-pages
+          folder: docs/public
+          clean-exclude: pr-preview/
+          force: false
 
-  deploy:
-    needs: build
-    # Deploy only on a real push/dispatch to main, never on pull requests.
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+  # PR previews: build with a per-PR baseURL and publish under
+  # gh-pages/pr-preview/pr-N; the action removes it when the PR closes.
+  preview:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write # deploy-pages publishes the built site to GitHub Pages
-      id-token: write # deploy-pages uses OIDC to verify the deployment origin
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
+      pull-requests: write
+    env:
+      HUGO_VERSION: 0.164.0
     steps:
-      # enablement turns Pages on automatically the first time, so no manual
-      # "Settings -> Pages -> GitHub Actions" step is needed.
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-        with:
-          enablement: true
+      - name: Install Hugo (extended)
+        if: github.event.action != 'closed'
+        run: |
+          deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
+          wget -O /tmp/hugo.deb "${base}/${deb}"
+          wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
+          sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
+          echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
+          sudo dpkg -i /tmp/hugo.deb
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # Always checked out so the deploy action can operate, even on close.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        if: github.event.action != 'closed'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: docs/go.mod
+
+      # The preview lives at <site>/pr-preview/pr-N/, so the absolute baseURL
+      # Hugo bakes into asset and link URLs must point at that subdirectory.
+      - name: Build with Hugo
+        if: github.event.action != 'closed'
+        working-directory: docs
+        env:
+          HUGO_ENVIRONMENT: production
+        run: hugo --minify --gc --baseURL "https://rayakame.github.io/sqlc-gen-better-python/pr-preview/pr-${{ github.event.number }}/"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/public
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,27 +4,28 @@ layout: hextra-home
 ---
 
 {{< hextra/hero-badge >}}
-  <div class="hx-w-2 hx-h-2 hx-rounded-full hx-bg-primary-400"></div>
+  <div class="hx:w-2 hx:h-2 hx:rounded-full hx:bg-primary-400"></div>
   <span>Free, open source, self-hosted</span>
 {{< /hextra/hero-badge >}}
 
-<div class="hx-mt-6 hx-mb-6">
+<div class="hx:mt-6 hx:mb-6">
 {{< hextra/hero-headline >}}
   Type-safe Python from your SQL
 {{< /hextra/hero-headline >}}
 </div>
 
-<div class="hx-mb-12">
+<div class="hx:mb-12">
 {{< hextra/hero-subtitle >}}
-  A sqlc plugin that generates modern, fully typed Python database&nbsp;<br class="sm:hx-block hx-hidden" />code from plain SQL - models plus async query functions.
+  A sqlc plugin that generates modern, fully typed Python database code from plain SQL - models plus async query functions.
 {{< /hextra/hero-subtitle >}}
 </div>
 
-<div class="hx-mb-6">
-{{< hextra/hero-button text="Get Started" link="docs/getting-started" >}}
+<div class="hx:mb-6 hx:flex hx:gap-4 hx:flex-wrap hx:items-center">
+{{< hextra/hero-button text="Documentation" link="docs" >}}
+{{< hextra/hero-button text="Join the Discord" link="https://discord.gg/hikari" style="background: #5865f2;" >}}
 </div>
 
-<div class="hx-mt-6"></div>
+<div class="hx:mt-6"></div>
 
 {{< hextra/feature-grid >}}
   {{< hextra/feature-card


### PR DESCRIPTION
## Summary

Two related pieces of docs-site work.

### Homepage hero
- Fix the hero spacing. The wrappers used the old `hx-` Tailwind prefix, which is a no-op in Hextra v0.12 (it uses `hx:`), so the margins collapsed and the hero elements ran together. Switched them to `hx:` and dropped the responsive `<br>` hack whose class is not in the theme's static CSS.
- Rename the primary hero button from "Get Started" to "Documentation", pointing at the docs index (`/docs`).
- Add a "Join the Discord" support button (https://discord.gg/hikari) next to it.

### Per-PR docs previews
Move docs hosting from the GitHub Actions Pages source to a `gh-pages` branch so previews can live beside the production site:
- `main` builds and publishes to the `gh-pages` root. `clean-exclude: pr-preview/` keeps the preview umbrella so a production deploy never deletes open previews; `force: false` rebases instead of force-pushing so concurrent preview pushes are tolerated.
- Each PR builds with a per-PR `--baseURL` and publishes under `gh-pages/pr-preview/pr-N/` via `rossjrw/pr-preview-action`, which comments the preview URL and removes the preview when the PR closes.

## Required manual step (after merge)

GitHub Pages allows only one source, so previews require the branch model. After this merges:
1. Wait for the `Docs` workflow `deploy` job to populate the `gh-pages` branch.
2. Settings -> Pages -> Build and deployment -> Source -> "Deploy from a branch" -> `gh-pages` / `(root)`.

Do step 2 after step 1, or the root site briefly 404s (the branch has no root site until the deploy job runs).

## Notes
- This PR's own preview is not viewable until `gh-pages` is the live Pages source (after the flip above). Working previews start on the next docs PR.
- Fork PRs get no preview: their token is read-only by design. Own-branch PRs get full previews. `pull_request_target` is deliberately not used, so there is no token-exposure risk.

## Verification
- Hugo builds clean (13 pages) for both the production baseURL and a simulated per-PR baseURL; asset and link URLs resolve correctly under `/pr-preview/pr-N/`, and the external Discord link is not rewritten.
- Workflow YAML validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic documentation previews for pull requests.
  * Documentation is now published directly to the documentation site, with previews managed throughout the pull request lifecycle.
  * Updated the homepage hero with separate **Documentation** and **Join the Discord** calls to action.
* **Style**
  * Refined hero layout, spacing, styling, and subtitle formatting for improved presentation.
* **Chores**
  * Updated the documentation deployment workflow and introduced a reusable Hugo (extended) installer for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->