### PR TITLE
ci(docs): pin hugo digest and serialize gh-pages writes

### DIFF
--- a/.github/actions/install-hugo/action.yml
+++ b/.github/actions/install-hugo/action.yml
@@ -3,7 +3,7 @@ description: Download, checksum-verify, and install the Hugo extended .deb packa
 
 inputs:
   hugo-version:
-    description: The Hugo version to install.
+    description: The Hugo version to install. Must have a pinned digest below.
     required: false
     default: "0.164.0"
 
@@ -14,10 +14,15 @@ runs:
       env:
         HUGO_VERSION: ${{ inputs.hugo-version }}
       run: |
+        # Digests are pinned here (established out of band from the official
+        # release) so a tampered release cannot pass verification by also
+        # swapping its checksum file. Bump this map when raising the version.
+        case "${HUGO_VERSION}" in
+          0.164.0) sha256="8325f3653032d0fc536503691f4833dc4eb6c6be02ee62466758f3f37a7f2fcd" ;;
+          *) echo "Unsupported Hugo version: ${HUGO_VERSION} (add its pinned digest to install-hugo)" >&2; exit 1 ;;
+        esac
         deb="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-        base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
-        wget -O /tmp/hugo.deb "${base}/${deb}"
-        wget -O /tmp/hugo_checksums.txt "${base}/hugo_${HUGO_VERSION}_checksums.txt"
-        sha="$(awk -v f="$deb" '$2 == f {print $1}' /tmp/hugo_checksums.txt)"
-        echo "${sha}  /tmp/hugo.deb" | sha256sum -c -
+        url="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${deb}"
+        wget -O /tmp/hugo.deb "${url}"
+        echo "${sha256}  /tmp/hugo.deb" | sha256sum -c -
         sudo dpkg -i /tmp/hugo.deb

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,11 @@ on:
 permissions:
   contents: read
 
-# Serialize per PR (and separately for main) so pushes to the gh-pages branch
-# do not race; never cancel an in-progress deploy.
+# One constant group serializes every docs run, so the deploy and preview
+# jobs never push to the gh-pages branch concurrently; never cancel an
+# in-progress deploy.
 concurrency:
-  group: docs-${{ github.event.pull_request.number || github.ref }}
+  group: docs-gh-pages
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Two hardening follow-ups to the docs workflow that were reviewed but did not make it into #189.

- **Pin the Hugo digest.** The install action verified the `.deb` against `hugo_checksums.txt` downloaded from the *same* release, so a tampered release could swap both and still pass. It now verifies against a version-specific digest pinned in the action (established once from the official release; `8325f36...` for 0.164.0) and rejects any version without a pinned digest. This also removes a download.
- **Serialize gh-pages writes.** The concurrency group was `docs-${{ pr.number || ref }}`, putting main and each PR in separate groups that could push to `gh-pages` concurrently. A single constant group (`docs-gh-pages`) serializes every docs run.

## Validation
- actionlint clean on `docs.yml`; both files valid YAML.
- Pinned digest matches the official Hugo 0.164.0 checksum.
