### PR TITLE
docs: mention that sqlc is pip-installable via sqlc-bin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,9 @@ that you should follow to ensure that your contribution is at its best.
 - [**sqlc**](https://docs.sqlc.dev/en/latest/overview/install.html) on your PATH, in the
   version CI pins (`sqlc-version` in `.github/workflows/ci.yml`). The sqlc version is
   stamped into every generated file header, so a different version diffs all fixtures.
+  The easiest way to get exactly that version without a Go toolchain is
+  [sqlc-bin](https://pypi.org/project/sqlc-bin/), whose package version tracks the
+  sqlc version: `uv tool install "sqlc-bin==1.31.1"`.
 - **Docker** (or a local PostgreSQL) - only needed for the runtime tests.
 
 One-time setup for the Python tooling:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A WASM plugin for SQLC allowing the generation of Python code.
 The generated code requires **Python 3.12 or newer** (it uses PEP 695 type
 aliases and generics, and `enum.StrEnum`).
 
+> [!TIP]
+> Besides the [official installation methods](https://docs.sqlc.dev/en/latest/overview/install.html),
+> the `sqlc` CLI itself is also pip-installable via
+> [`sqlc-bin`](https://pypi.org/project/sqlc-bin/), which ships the unmodified
+> official binaries - no Go toolchain required: `pip install sqlc-bin` (or
+> `uv add --dev sqlc-bin`) puts `sqlc` on your PATH, pinnable like any other
+> Python dependency.
+
 ## Documentation
 
 **https://rayakame.github.io/sqlc-gen-better-python/**

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -16,6 +16,14 @@ You need [`sqlc`](https://docs.sqlc.dev/en/latest/overview/install.html) on your
 `PATH` and **Python 3.12 or newer** (the generated code uses PEP 695 type aliases
 and generics, and `enum.StrEnum`).
 
+{{< callout type="info" >}}
+  Besides the official installation methods, sqlc is also pip-installable via
+  [sqlc-bin](https://pypi.org/project/sqlc-bin/), which ships the unmodified
+  official binaries - no Go toolchain required. `uv add --dev sqlc-bin` (or
+  `pip install sqlc-bin`) puts `sqlc` on your PATH, and the package version
+  tracks the sqlc version, so you can pin it like any other dependency.
+{{< /callout >}}
+
 Then install the database driver you want to use:
 
 {{< tabs >}}


### PR DESCRIPTION
Notes in the docs that besides the [official installation methods](https://docs.sqlc.dev/en/latest/overview/install.html), the `sqlc` CLI can also be installed with pip/uv via [`sqlc-bin`](https://pypi.org/project/sqlc-bin/) ([repo](https://github.com/rayakame/sqlc-bin)) - the unmodified official sqlc binaries as platform wheels, no Go toolchain required, with the package version tracking the sqlc version so it pins like any other Python dependency.

- **README**: a tip alert under the intro.
- **getting-started**: an info callout in the Prerequisites section.
- **CONTRIBUTING**: the sqlc prerequisite now points at `uv tool install "sqlc-bin==1.31.1"` as the easiest way to get exactly the CI-pinned version (this pin needs bumping together with `sqlc-version` in ci.yml on future sqlc upgrades).

Docs-only change, hence the skip-fragment-check label.