### PR TITLE
docs: show the PARSE_DECLTYPES note only on the sqlite tabs

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -522,6 +522,13 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+{{< callout type="info" >}}
+  The `detect_types=sqlite3.PARSE_DECLTYPES` above is not needed for this schema,
+  but it is what makes generated converters work once your tables use dates,
+  decimals, booleans, or blobs. See
+  [SQLite type conversion](/docs/guide/sqlite-type-conversion).
+{{< /callout >}}
+
   {{< /tab >}}
 
   {{< tab name="sqlite3" >}}
@@ -545,16 +552,16 @@ for user in query.list_users(conn):
     print(user.name)
 ```
 
-  {{< /tab >}}
-
-{{< /tabs >}}
-
 {{< callout type="info" >}}
   The `detect_types=sqlite3.PARSE_DECLTYPES` above is not needed for this schema,
   but it is what makes generated converters work once your tables use dates,
   decimals, booleans, or blobs. See
   [SQLite type conversion](/docs/guide/sqlite-type-conversion).
 {{< /callout >}}
+
+  {{< /tab >}}
+
+{{< /tabs >}}
 
 ## Next steps
 


### PR DESCRIPTION
In the getting-started guide, the callout explaining `detect_types=sqlite3.PARSE_DECLTYPES` was placed after the closing `{{< /tabs >}}` of the **Use it** section, so it rendered for every driver selection - including the PostgreSQL drivers it does not apply to.

The callout now lives inside the `aiosqlite` and `sqlite3` tabs, directly under the code samples that contain the `detect_types` argument it refers to, and disappears when a PostgreSQL driver tab is selected.

Docs-only change, hence the skip-fragment-check label.