### PR TITLE
docs: note that asyncpg typing needs asyncpg-stubs

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -31,8 +31,11 @@ Then install the database driver you want to use:
   {{< tab name="asyncpg" >}}
 
 ```bash
-pip install asyncpg
+pip install asyncpg asyncpg-stubs
 ```
+
+asyncpg has no strict typing of its own; [asyncpg-stubs](https://pypi.org/project/asyncpg-stubs/)
+makes the generated annotations work under pyright and mypy.
 
   {{< /tab >}}
 

--- a/docs/content/docs/guide/drivers.md
+++ b/docs/content/docs/guide/drivers.md
@@ -50,9 +50,8 @@ asyncpg supports `:copyfrom` (bulk insert via `copy_records_to_table`).
   asyncpg itself ships without strict type annotations - install
   [asyncpg-stubs](https://pypi.org/project/asyncpg-stubs/) so that pyright or
   mypy understand generated annotations like
-  `asyncpg.Connection[asyncpg.Record]`. This only affects type checking:
-  the generated `ConnectionLike` alias is a lazy PEP 695 `type` statement
-  inside the `TYPE_CHECKING` block, so it is never evaluated at runtime.
+  `asyncpg.Connection[asyncpg.Record]`. This only affects type checking and
+  is never evaluated at runtime.
 {{< /callout >}}
 
 ## psycopg_async (PostgreSQL)

--- a/docs/content/docs/guide/drivers.md
+++ b/docs/content/docs/guide/drivers.md
@@ -46,6 +46,15 @@ asyncio.run(main())
 
 asyncpg supports `:copyfrom` (bulk insert via `copy_records_to_table`).
 
+{{< callout type="info" >}}
+  asyncpg itself ships without strict type annotations - install
+  [asyncpg-stubs](https://pypi.org/project/asyncpg-stubs/) so that pyright or
+  mypy understand generated annotations like
+  `asyncpg.Connection[asyncpg.Record]`. This only affects type checking:
+  the generated `ConnectionLike` alias is a lazy PEP 695 `type` statement
+  inside the `TYPE_CHECKING` block, so it is never evaluated at runtime.
+{{< /callout >}}
+
 ## psycopg_async (PostgreSQL)
 
 ```python


### PR DESCRIPTION
asyncpg ships without strict type annotations, so the generated `ConnectionLike` alias (`asyncpg.Connection[asyncpg.Record] | ...`) only type-checks with [asyncpg-stubs](https://pypi.org/project/asyncpg-stubs/) installed

Closes #231 