### PR TITLE
chore: soften the release-body note to match the README tone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
           yq -i '.plugins[0].wasm.url = env(download_url)' .github/release_output_template.yaml
           yq -i '.plugins[0].wasm.sha256 = env(checksum)' .github/release_output_template.yaml
           
-          # Create the release body with the warning message at the top
-          echo "> [!WARNING]" > release_body.md
-          echo "> Every Release before \`v1.0.0\`, including this one is an **early alpha release**. These versions are only released for interested people who want to test this plugin and help make it better." >> release_body.md
+          # Create the release body with the pre-1.0 note at the top
+          echo "> [!NOTE]" > release_body.md
+          echo "> Releases before \`v1.0.0\` are **beta releases**: options and generated output may still change between minor versions. Everything that ships is tested against real databases and already used in production." >> release_body.md
           
           # Add the release changelog and YAML content below the warning message
           cat .changes/${{ steps.latest.outputs.output }}.md >> release_body.md


### PR DESCRIPTION
Replaces the early-alpha warning in generated release notes with the beta note the README used to carry.